### PR TITLE
Fix broken links

### DIFF
--- a/content/contributing.md
+++ b/content/contributing.md
@@ -5,7 +5,7 @@ title = "How to Contribute"
 If you're interested in contributing to the Ruma project, this page offers some pointers on how to get started.
 
 The most significant thing you can do to help the project is to try to build something using it.
-Since homeserver development has ended, this means building something like a bot or GUI client using the [ruma-client](https://www.ruma.io/projects/ruma-client/) library.
+Since homeserver development has ended, this means building something like a bot or GUI client using the [ruma-client](/docs/crates/ruma-client/) library.
 As you work, you can help by opening issues and/or pull requests on the relevant Ruma libraries as issues come up.
 This will help ensure that Ruma is suitable for real-world use cases.
 
@@ -18,7 +18,7 @@ One such project already exists: [olm-rs](https://crates.io/crates/olm-rs).
 olm-rs might need some additional help.
 If you're very confident in your skills with implementing cryptographic algorithms, you could attempt to port Olm to Rust directly, though it's not clear if this would be possible without any C code at all.
 
-The second major area where code contributions would help would be to work on equivalents of [ruma-client-api](https://www.ruma.io/projects/ruma-client-api/) for the other Matrix APIs (e.g. [federation](https://matrix.org/docs/spec/server_server/latest).)
+The second major area where code contributions would help would be to work on equivalents of [ruma-client-api](/docs/crates/ruma-client-api/) for the other Matrix APIs (e.g. [federation](https://matrix.org/docs/spec/server_server/latest).)
 ruma-client-api is the library that defines the Rust interface for all the HTTP endpoints in the Matrix client-server API.
 An equivalent library will eventually be needed for the other Matrix APIs.
 

--- a/content/docs/crates/ruma-appservice-api.md
+++ b/content/docs/crates/ruma-appservice-api.md
@@ -4,4 +4,4 @@ extra.crate = "ruma-appservice-api"
 +++
 
 `ruma-appservice-api` contains serializable types for the requests and responses for each endpoint in the Matrix appservice API.
-It implements the generic interface for Matrix APIs defined in [ruma-api](/projects/ruma-api/).
+It implements the generic interface for Matrix APIs defined in [ruma-api](/docs/crates/ruma-api/).

--- a/content/docs/crates/ruma-client-api.md
+++ b/content/docs/crates/ruma-client-api.md
@@ -4,4 +4,4 @@ extra.crate = "ruma-client-api"
 +++
 
 `ruma-client-api` contains serializable types for the requests and responses for each endpoint in the Matrix client-server API.
-It implements the generic interface for Matrix APIs defined in [ruma-api](/projects/ruma-api/).
+It implements the generic interface for Matrix APIs defined in [ruma-api](/docs/crates/ruma-api/).

--- a/content/docs/crates/ruma-client.md
+++ b/content/docs/crates/ruma-client.md
@@ -4,5 +4,5 @@ extra.crate = "ruma-client"
 +++
 
 `ruma-client` is a high-level client for Matrix's client-server API.
-It implements the client side of the request and response types defined in [ruma-client-api](/projects/ruma-client-api/), which in turn implements a generic Matrix API interface defined in [ruma-api](/projects/ruma-api/).
+It implements the client side of the request and response types defined in [ruma-client-api](/docs/crates/ruma-client-api/), which in turn implements a generic Matrix API interface defined in [ruma-api](/docs/crates/ruma-api/).
 `ruma-client` is the library that most developers writing applications that integrate with Matrix will need, since it is the one that makes requests to the primary homeserver API.

--- a/content/docs/crates/ruma-federation-api.md
+++ b/content/docs/crates/ruma-federation-api.md
@@ -4,4 +4,4 @@ extra.crate = "ruma-federation-api"
 +++
 
 `ruma-federation-api` contains serializable types for the requests and responses for each endpoint in the Matrix federation API.
-It implements the generic interface for Matrix APIs defined in [ruma-api](/projects/ruma-api/).
+It implements the generic interface for Matrix APIs defined in [ruma-api](/docs/crates/ruma-api/).

--- a/content/docs/crates/ruma-push-gateway-api.md
+++ b/content/docs/crates/ruma-push-gateway-api.md
@@ -5,4 +5,4 @@ extra.crate = "ruma-push-gateway-api"
 
 `ruma-push-gateway-api` contains serializable types for the requests and responses for each endpoint
 in the Matrix push gateway API (though at the time of writing there is only a single endpoint).
-It implements the generic interface for Matrix APIs defined in [ruma-api](/projects/ruma-api/).
+It implements the generic interface for Matrix APIs defined in [ruma-api](/docs/crates/ruma-api/).

--- a/content/news/this-week-in-ruma-2016-12-11.md
+++ b/content/news/this-week-in-ruma-2016-12-11.md
@@ -51,4 +51,4 @@ Adding or improving documentation, doing code review, and participating in discu
 * \[feature\] [Implement a rate-limiting middleware](https://github.com/ruma/ruma/issues/107)
 
 There are also plenty of API endpoints that still need to be implemented.
-Check the [status document](https://github.com/ruma/ruma/blob/master/STATUS.md) for a list.
+Check the [status document](https://github.com/ruma/homeserver/blob/master/STATUS.md) for a list.

--- a/content/news/this-week-in-ruma-2017-01-01.md
+++ b/content/news/this-week-in-ruma-2017-01-01.md
@@ -78,4 +78,4 @@ Previously featured and still available:
 * \[discussion\] [Protect against database concurrency bugs](https://github.com/ruma/ruma/issues/132)
 
 There are also plenty of API endpoints that still need to be implemented.
-Check the [status document](https://github.com/ruma/ruma/blob/master/STATUS.md) for a list.
+Check the [status document](https://github.com/ruma/homeserver/blob/master/STATUS.md) for a list.

--- a/content/news/this-week-in-ruma-2017-01-15.md
+++ b/content/news/this-week-in-ruma-2017-01-15.md
@@ -71,4 +71,4 @@ Previously featured and still available:
 * \[feature\] [Implement a rate-limiting middleware](https://github.com/ruma/ruma/issues/107)
 
 There are also plenty of API endpoints that still need to be implemented.
-Check the [status document](https://github.com/ruma/ruma/blob/master/STATUS.md) for a list.
+Check the [status document](https://github.com/ruma/homeserver/blob/master/STATUS.md) for a list.

--- a/content/news/this-week-in-ruma-2017-02-05.md
+++ b/content/news/this-week-in-ruma-2017-02-05.md
@@ -58,4 +58,4 @@ Previously featured and still available:
 * \[feature\] [Implement a rate-limiting middleware](https://github.com/ruma/ruma/issues/107)
 
 There are also plenty of API endpoints that still need to be implemented.
-Check the [status document](https://github.com/ruma/ruma/blob/master/STATUS.md) for a list.
+Check the [status document](https://github.com/ruma/homeserver/blob/master/STATUS.md) for a list.

--- a/content/news/this-week-in-ruma-2017-02-12.md
+++ b/content/news/this-week-in-ruma-2017-02-12.md
@@ -44,4 +44,4 @@ Previously featured and still available:
 * \[feature\] [Implement a rate-limiting middleware](https://github.com/ruma/ruma/issues/107)
 
 There are also plenty of API endpoints that still need to be implemented.
-Check the [status document](https://github.com/ruma/ruma/blob/master/STATUS.md) for a list.
+Check the [status document](https://github.com/ruma/homeserver/blob/master/STATUS.md) for a list.

--- a/content/news/this-week-in-ruma-2017-02-19.md
+++ b/content/news/this-week-in-ruma-2017-02-19.md
@@ -37,4 +37,4 @@ Previously featured and still available:
 * \[feature\] [Implement a rate-limiting middleware](https://github.com/ruma/ruma/issues/107)
 
 There are also plenty of API endpoints that still need to be implemented.
-Check the [status document](https://github.com/ruma/ruma/blob/master/STATUS.md) for a list.
+Check the [status document](https://github.com/ruma/homeserver/blob/master/STATUS.md) for a list.

--- a/content/news/this-week-in-ruma-2017-05-14.md
+++ b/content/news/this-week-in-ruma-2017-05-14.md
@@ -66,4 +66,4 @@ Previously featured and still available:
 * \[feature\] [Implement a rate-limiting middleware](https://github.com/ruma/ruma/issues/107)
 
 There are also plenty of API endpoints that still need to be implemented.
-Check the [status document](https://github.com/ruma/ruma/blob/master/STATUS.md) for a list.
+Check the [status document](https://github.com/ruma/homeserver/blob/master/STATUS.md) for a list.

--- a/templates/project.html
+++ b/templates/project.html
@@ -18,7 +18,7 @@
         <ul>
             <li><a href="https://crates.io/crates/{{ crate }}">crates.io page</a></li>
             <li><a href="https://docs.rs/{{ crate }}">Documentation</a></li>
-            <li><a href="{{ repo }}/tree/master/{{ crate }}">Code</a></li>
+            <li><a href="{{ repo }}/tree/main/{{ crate }}">Code</a></li>
             <li>
                 <a href="{{ repo }}/issues?q=is%3Aissue+is%3Aopen+label%3Acrate%2F{{ crate }}">
                     Issues


### PR DESCRIPTION
Hey there! Was looking through the site and noticed some broken links. Let me know if these changes look good to you!

I also noticed that a lot of the news articles point to a `https://github.com/ruma/ruma/blob/master/STATUS.md` that doesn't exist anymore. I wasn't sure if there a more appropriate link or if it's worth changing past articles like that, so left them alone. If you would like me to update those something, let me know and I can add them to this PR!