### PR TITLE
Remove actions permission

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,6 @@ jobs:
     name: Build and deploy the site
     runs-on: ubuntu-latest
     permissions:
-      actions: read
       contents: read
       pages: write
       id-token: write


### PR DESCRIPTION
This was only needed in actions/deploy-pages v4.0.0 but has been fixed in [v4.0.1](https://github.com/actions/deploy-pages/releases/tag/v4.0.1).