### PR TITLE
Update Fractal info

### DIFF
--- a/content/projects.md
+++ b/content/projects.md
@@ -15,7 +15,7 @@ libraries that make up Ruma, is available [here](/docs/crates/).*
 high-level client library on top of the Ruma libraries. There are a few client
 applications built with it:
 
-* [Fractal]: A GTK client (part of the GNOME project)
+* [Fractal]: A client for GNOME
 * [RumaTui]: A command-line client
 * [retrix]: A lightweight client built with [iced]
 * [Weechat-Matrix]: A plugin for weechat that adds Matrix support to it
@@ -31,7 +31,7 @@ Additionally, some bots are also being built with it:
 [matrix-rust-sdk]: https://github.com/matrix-org/matrix-rust-sdk#matrix-rust-sdk
 [matrix-sdk]: https://crates.io/crates/matrix-sdk
 
-[Fractal]: https://wiki.gnome.org/Apps/Fractal
+[Fractal]: https://gitlab.gnome.org/World/fractal
 [RumaTui]: https://github.com/DevinR528/RumaTui#readme
 [retrix]: https://git.graven.dev/amanda/retrix
 [iced]: https://github.com/hecrj/iced#readme


### PR DESCRIPTION
We are not technically part of GNOME, we just use GNOME's infrastructure and libraries. The wiki page was outdated and is now a redirect to our repository.